### PR TITLE
fix IndentationError in openstack connection

### DIFF
--- a/module/sources/openstack/connection.py
+++ b/module/sources/openstack/connection.py
@@ -397,7 +397,7 @@ class OpenStackHandler(SourceBase):
 
             return False
 
-      if object_type not in [NBDevice, NBVM]:
+        if object_type not in [NBDevice, NBVM]:
             raise ValueError(f"Object must be a '{NBVM.name}' or '{NBDevice.name}'.")
 
         if primary_ip4 is None and primary_ip6 is None:


### PR DESCRIPTION
```
  File "/home/gregory/github_forks/netbox-sync/module/sources/openstack/connection.py", line 400
    if object_type not in [NBDevice, NBVM]:
                                           ^
IndentationError: unindent does not match any outer indentation level
```